### PR TITLE
chore: bump version to 1.0.7 and update readme for changelog

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'VERSATILE_VERSION', '1.0.6' );
+define( 'VERSATILE_VERSION', '1.0.7' );
 define( 'VERSATILE_PLUGIN_NAME', 'versatile-toolkit' );
 define( 'VERSATILE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VERSATILE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: troubleshooting, temporary login, maintenance mode, coming soon, IP contro
 Requires at least: 5.3
 Tested up to: 6.9.4
 Requires PHP: 7.4
-Stable tag: 1.0.4
+Stable tag: 1.0.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -91,7 +91,7 @@ Source code link : https://github.com/nur-alam/versatile
 
 == Changelog ==
 
-= 1.0.6 =
+= 1.0.7 =
 * Added "Quick Action" feature for one-click permalink reset, plugin & themes activation and deactivation
 
 = 1.0.4 =

--- a/versatile-toolkit.php
+++ b/versatile-toolkit.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Versatile Toolkit
- * Version: 1.0.6
+ * Version: 1.0.7
  * Requires at least: 5.3
  * Requires PHP: 7.4
  * Plugin URI: https://verspark.com/


### PR DESCRIPTION
- Update version number in constants.php and versatile-toolkit.php to 1.0.7.
- Change stable tag in readme.txt to 1.0.7.
- Add changelog entry for the new version reflecting the Quick Action feature.