### PR TITLE
feat(debug-log): add source filtering and detection for debug logs

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'VERSATILE_VERSION', '1.0.10' );
+define( 'VERSATILE_VERSION', '1.0.11' );
 define( 'VERSATILE_PLUGIN_NAME', 'versatile-toolkit' );
 define( 'VERSATILE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VERSATILE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/inc/Services/Troubleshoot/DebugLog.php
+++ b/inc/Services/Troubleshoot/DebugLog.php
@@ -229,6 +229,15 @@ class DebugLog {
 				);
 			}
 
+			if (! empty($_GET['source'])) { // phpcs:ignore
+				$build_array_for_validation[] = array(
+					'name'     => 'source',
+					'value'    => wp_unslash($_GET['source']), // phpcs:ignore
+					'sanitize' => 'sanitize_text_field',
+					'rules'    => '',
+				);
+			}
+
 			$sanitized_data = versatile_sanitization_validation(
 				$build_array_for_validation
 			);
@@ -258,13 +267,26 @@ class DebugLog {
 
 			$page     = isset( $verified_data->page ) ? (int) $verified_data->page : 1;
 			$per_page = isset( $verified_data->per_page ) ? (int) $verified_data->per_page : 20;
+			$source   = isset( $verified_data->source ) ? (string) $verified_data->source : '';
 
 			$lines = file( $log_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
 
 			// Parse complete error entries (multi-line support)
 			$error_entries = $this->parse_complete_error_entries( $lines );
+
+			if ( ! empty( $source ) && 'all' !== $source ) {
+				$error_entries = array_values(
+					array_filter(
+						$error_entries,
+						function ( $entry ) use ( $source ) {
+							return isset( $entry['source_value'] ) && $entry['source_value'] === $source;
+						}
+					)
+				);
+			}
+
 			$total_entries = count( $error_entries );
-			$total_pages   = ceil( $total_entries / $per_page );
+			$total_pages   = $per_page > 0 ? (int) ceil( $total_entries / $per_page ) : 0;
 
 			// Reverse entries to show newest first
 			$error_entries = array_reverse( $error_entries );
@@ -313,6 +335,10 @@ class DebugLog {
 				if ( ! preg_match( '/^\[([^\]]+)\]\s+(Automatic\s+updates|WordPress\s+database\s+error)/i', $line ) ) {
 					$current_error['message']  .= "\n" . trim( $line );
 					$current_error['raw_line'] .= "\n" . $line;
+					$current_error              = array_merge(
+						$current_error,
+						$this->detect_log_source( $current_error['raw_line'], $current_error['file'] ?? '' )
+					);
 				}
 			}
 		}
@@ -354,31 +380,209 @@ class DebugLog {
 				$stack_trace = isset( $parts[1] ) ? trim( $parts[1] ) : '';
 			}
 
-			return array(
-				'id'          => $line_number,
-				'timestamp'   => $timestamp,
-				'type'        => $type,
-				'severity'    => $severity,
-				'message'     => $message,
-				'file'        => $file,
-				'line'        => $line_num,
-				'stack_trace' => $stack_trace,
-				'raw_line'    => $line,
+			return array_merge(
+				array(
+					'id'          => $line_number,
+					'timestamp'   => $timestamp,
+					'type'        => $type,
+					'severity'    => $severity,
+					'message'     => $message,
+					'file'        => $file,
+					'line'        => $line_num,
+					'stack_trace' => $stack_trace,
+					'raw_line'    => $line,
+				),
+				$this->detect_log_source( $line, $file )
 			);
 		}
 
 		// If it doesn't match the standard format, treat as generic log entry
-		return array(
-			'id'          => $line_number,
-			'timestamp'   => '',
-			'type'        => 'Unknown',
-			'severity'    => 'info',
-			'message'     => $line,
-			'file'        => '',
-			'line'        => '',
-			'stack_trace' => '',
-			'raw_line'    => $line,
+		return array_merge(
+			array(
+				'id'          => $line_number,
+				'timestamp'   => '',
+				'type'        => 'Unknown',
+				'severity'    => 'info',
+				'message'     => $line,
+				'file'        => '',
+				'line'        => '',
+				'stack_trace' => '',
+				'raw_line'    => $line,
+			),
+			$this->detect_log_source( $line )
 		);
+	}
+
+	/**
+	 * Detect the most likely source for a log entry.
+	 *
+	 * @param string $content Full log content for the entry.
+	 * @param string $file    Main file extracted from the first log line.
+	 * @return array<string, string>
+	 */
+	private function detect_log_source( $content, $file = '' ) {
+		$haystack = trim( $content . "\n" . $file );
+		$matches  = array();
+
+		if ( preg_match( '#/wp-content/plugins/([^/\s]+)#i', $haystack, $plugin_match, PREG_OFFSET_CAPTURE ) ) {
+			$plugin_slug = $this->normalize_source_slug( $plugin_match[1][0] );
+			$plugin_list = $this->get_plugin_lookup();
+			$matches[]   = array(
+				'offset'       => $plugin_match[0][1],
+				'source_type'  => 'plugin',
+				'source_slug'  => $plugin_slug,
+				'source_label' => $plugin_list[ $plugin_slug ] ?? $this->format_source_label( $plugin_slug ),
+				'source_value' => 'plugin:' . $plugin_slug,
+			);
+		}
+
+		if ( preg_match( '#/wp-content/themes/([^/\s]+)#i', $haystack, $theme_match, PREG_OFFSET_CAPTURE ) ) {
+			$theme_slug = $this->normalize_source_slug( $theme_match[1][0] );
+			$theme_list = $this->get_theme_lookup();
+			$matches[]  = array(
+				'offset'       => $theme_match[0][1],
+				'source_type'  => 'theme',
+				'source_slug'  => $theme_slug,
+				'source_label' => $theme_list[ $theme_slug ] ?? $this->format_source_label( $theme_slug ),
+				'source_value' => 'theme:' . $theme_slug,
+			);
+		}
+
+		if ( preg_match( '#/wp-content/mu-plugins/([^/\s]+)#i', $haystack, $mu_plugin_match, PREG_OFFSET_CAPTURE ) ) {
+			$mu_plugin_slug = $this->normalize_source_slug( $mu_plugin_match[1][0] );
+			$matches[]      = array(
+				'offset'       => $mu_plugin_match[0][1],
+				'source_type'  => 'mu-plugin',
+				'source_slug'  => $mu_plugin_slug,
+				'source_label' => $this->format_source_label( $mu_plugin_slug ),
+				'source_value' => 'mu-plugin:' . $mu_plugin_slug,
+			);
+		}
+
+		if ( ! empty( $matches ) ) {
+			usort(
+				$matches,
+				function ( $left, $right ) {
+					return $left['offset'] <=> $right['offset'];
+				}
+			);
+
+			$source = $matches[0];
+			unset( $source['offset'] );
+			$source['log_from'] = $source['source_label'];
+
+			return $source;
+		}
+
+		if ( preg_match( '#/(wp-admin|wp-includes)/#i', $file ? $file : $haystack ) ) {
+			return array(
+				'source_type'  => 'wordpress-core',
+				'source_slug'  => 'wordpress-core',
+				'source_label' => 'WordPress Core',
+				'source_value' => 'wordpress-core',
+				'log_from'     => 'WordPress Core',
+			);
+		}
+
+		return array(
+			'source_type'  => 'unknown',
+			'source_slug'  => 'unknown',
+			'source_label' => 'Unknown',
+			'source_value' => 'unknown',
+			'log_from'     => 'Unknown',
+		);
+	}
+
+	/**
+	 * Build a lookup of plugin directory slugs to plugin names.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_plugin_lookup() {
+		static $plugin_lookup = null;
+
+		if ( null !== $plugin_lookup ) {
+			return $plugin_lookup;
+		}
+
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_lookup = array();
+		$all_plugins   = get_plugins();
+
+		foreach ( $all_plugins as $plugin_file => $plugin ) {
+			if ( empty( $plugin['Name'] ) ) {
+				continue;
+			}
+
+			$plugin_slug                   = $this->normalize_plugin_file_slug( $plugin_file );
+			$plugin_lookup[ $plugin_slug ] = $plugin['Name'];
+		}
+
+		return $plugin_lookup;
+	}
+
+	/**
+	 * Build a lookup of theme slugs to theme names.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_theme_lookup() {
+		static $theme_lookup = null;
+
+		if ( null !== $theme_lookup ) {
+			return $theme_lookup;
+		}
+
+		$theme_lookup = array();
+		$all_themes   = wp_get_themes();
+
+		foreach ( $all_themes as $theme_slug => $theme ) {
+			$theme_lookup[ $this->normalize_source_slug( $theme_slug ) ] = $theme->get( 'Name' );
+		}
+
+		return $theme_lookup;
+	}
+
+	/**
+	 * Normalize a plugin file path into the slug used by log paths.
+	 *
+	 * @param string $plugin_file Plugin file path.
+	 * @return string
+	 */
+	private function normalize_plugin_file_slug( $plugin_file ) {
+		$plugin_dir = dirname( $plugin_file );
+
+		if ( '.' !== $plugin_dir ) {
+			return $this->normalize_source_slug( $plugin_dir );
+		}
+
+		return $this->normalize_source_slug( basename( $plugin_file, '.php' ) );
+	}
+
+	/**
+	 * Normalize a detected source slug.
+	 *
+	 * @param string $slug Raw slug.
+	 * @return string
+	 */
+	private function normalize_source_slug( $slug ) {
+		$slug = wp_basename( str_replace( '\\', '/', $slug ) );
+		$slug = preg_replace( '/\.php$/i', '', $slug );
+
+		return strtolower( (string) $slug );
+	}
+
+	/**
+	 * Convert a slug into a readable label.
+	 *
+	 * @param string $slug Source slug.
+	 * @return string
+	 */
+	private function format_source_label( $slug ) {
+		return ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: troubleshooting, temporary login, maintenance mode, coming soon, IP contro
 Requires at least: 5.3
 Tested up to: 6.9.4
 Requires PHP: 7.4
-Stable tag: 1.0.10
+Stable tag: 1.0.11
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -91,8 +91,9 @@ Source code link : https://github.com/nur-alam/versatile
 
 == Changelog ==
 
-= 1.0.10 =
+= 1.0.11 =
 * Quick Top actions like reset permalink, plugin & theme activate/deactivation also deletion.
+* Debug log source & filter debug log by plugins or themes
 * Quick Action UI sync with versatile ui components.
 * Tailwind class prefixing with vt
 

--- a/src/pages/troubleshoot/debugLog/debug-log.tsx
+++ b/src/pages/troubleshoot/debugLog/debug-log.tsx
@@ -1,33 +1,77 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
 import { Column, ServerDataTable, TFetchDataPromise } from '@/pages/troubleshoot/debugLog/data-table';
 import DebugLogSettings from '@/pages/troubleshoot/debugLog/debug-log-settings';
 import { ViewLog } from '@/pages/troubleshoot/debugLog/view-log';
 import {
 	debugLogApi,
 	DebugRow,
+	DebugLogSearchParams,
 	formatFileInfo,
 	useClearDebugLog,
 	useDebugLogStatus,
 	useToggleDebugLog,
 } from '@/services/debug-log-services';
+import { useGetPluginList, useGetThemeList } from '@/services/versatile-services';
 import { LogTypeDisplay } from '@/utils/log-type-utils';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+type LogSourceListItem = {
+	slug: string;
+	label: string;
+};
+
+type LogSourceOption = {
+	value: string;
+	label: string;
+	group: 'general' | 'plugin' | 'theme';
+};
+
+const normalizePluginSourceSlug = (pluginSlug: string) => {
+	const [rootSegment = pluginSlug] = pluginSlug.split('/');
+	return rootSegment.replace(/\.php$/i, '').toLowerCase();
+};
+
+const formatSourceType = (sourceType?: string) => {
+	switch (sourceType) {
+		case 'plugin':
+			return __('Plugin', 'versatile-toolkit');
+		case 'theme':
+			return __('Theme', 'versatile-toolkit');
+		case 'mu-plugin':
+			return __('MU Plugin', 'versatile-toolkit');
+		case 'wordpress-core':
+			return __('WordPress Core', 'versatile-toolkit');
+		default:
+			return __('Unknown', 'versatile-toolkit');
+	}
+};
 
 const debugLog = () => {
 	// Use React Router's useSearchParams for hash-based routing
 	const [searchParams] = useSearchParams();
+	const navigate = useNavigate();
 
 	// Auto refresh state
 	const [isAutoRefresh, setIsAutoRefresh] = useState(false);
 	const [refreshTrigger, setRefreshTrigger] = useState(0);
+	const [selectedSource, setSelectedSource] = useState('all');
+	const [isSourceFilterOpen, setIsSourceFilterOpen] = useState(false);
 
 	// React Query hooks
 	const { data: statusData, isLoading: statusLoading, refetch: refetchStatus } = useDebugLogStatus();
 	const toggleMutation = useToggleDebugLog();
 	const clearMutation = useClearDebugLog();
+	const { data: pluginListData } = useGetPluginList();
+	const { data: themeListData } = useGetThemeList();
 
 	// Derived state
 	const debugStatus = statusData?.enabled || false;
@@ -107,6 +151,60 @@ const debugLog = () => {
 		setIsAutoRefresh(enable);
 	};
 
+	const handleSourceFilterChange = (sourceValue: string) => {
+		setSelectedSource(sourceValue);
+		setIsSourceFilterOpen(false);
+
+		const nextParams = new URLSearchParams(searchParams);
+		nextParams.set('paged', '1');
+
+		navigate({
+			pathname: '/troubleshoot/debug-log',
+			search: `?${nextParams.toString()}`,
+		});
+	};
+
+	const { generalOptions, pluginOptions, themeOptions } = useMemo(() => {
+		const pluginMap = new Map<string, string>();
+		const themeMap = new Map<string, string>();
+
+		((pluginListData?.data as LogSourceListItem[] | undefined) ?? []).forEach((plugin) => {
+			pluginMap.set(`plugin:${normalizePluginSourceSlug(plugin.slug)}`, plugin.label);
+		});
+
+		((themeListData?.data as LogSourceListItem[] | undefined) ?? []).forEach((theme) => {
+			themeMap.set(`theme:${theme.slug.toLowerCase()}`, theme.label);
+		});
+
+		return {
+			generalOptions: [
+				{ value: 'all', label: __('All Sources', 'versatile-toolkit'), group: 'general' as const },
+				{
+					value: 'wordpress-core',
+					label: __('WordPress Core', 'versatile-toolkit'),
+					group: 'general' as const,
+				},
+				{ value: 'unknown', label: __('Unknown', 'versatile-toolkit'), group: 'general' as const },
+			],
+			pluginOptions: Array.from(pluginMap.entries()).map(
+				([value, label]) => ({ value, label, group: 'plugin' as const }) satisfies LogSourceOption,
+			),
+			themeOptions: Array.from(themeMap.entries()).map(
+				([value, label]) => ({ value, label, group: 'theme' as const }) satisfies LogSourceOption,
+			),
+		};
+	}, [pluginListData, themeListData]);
+
+	const selectedSourceOption = useMemo(
+		() => [...generalOptions, ...pluginOptions, ...themeOptions].find((option) => option.value === selectedSource),
+		[generalOptions, pluginOptions, selectedSource, themeOptions],
+	);
+
+	const fetchLogContent = useCallback(
+		(params: DebugLogSearchParams) => debugLogApi.loadLogContent({ ...params, source: selectedSource }),
+		[selectedSource],
+	);
+
 	const columns = [
 		{ key: 'id', header: 'No' },
 		{
@@ -119,8 +217,24 @@ const debugLog = () => {
 		{
 			key: 'message',
 			header: 'Description',
-			render: (row, key?: string) => {
-				return <>{row['raw_line'].substring(0, 200)}...</>;
+			render: (row) => {
+				const messagePreview =
+					row['raw_line'].length > 200 ? `${row['raw_line'].substring(0, 200)}...` : row['raw_line'];
+				return <>{messagePreview}</>;
+			},
+		},
+		{
+			key: 'log_from',
+			header: 'Log From',
+			render: (row) => {
+				return (
+					<div className="vt-min-w-[11rem]">
+						<Badge variant="success" className="vt-font-medium">
+							{row['log_from'] || __('Unknown', 'versatile-toolkit')}
+						</Badge>
+						{/* <div className="vt-text-xs vt-text-slate-500">{formatSourceType(row['source_type'])}</div> */}
+					</div>
+				);
 			},
 		},
 		// { key: "severity", header: "Severity" },
@@ -241,6 +355,89 @@ const debugLog = () => {
 						{__('Debug Log', 'versatile-toolkit')}
 					</h3>
 					<div className="vt-flex vt-flex-wrap vt-items-center vt-gap-3">
+						<Popover open={isSourceFilterOpen} onOpenChange={setIsSourceFilterOpen}>
+							<PopoverTrigger asChild>
+								<Button
+									variant="outline"
+									role="combobox"
+									aria-expanded={isSourceFilterOpen}
+									aria-label={__('Filter debug logs by source', 'versatile-toolkit')}
+									className="vt-min-w-[12rem] vt-max-w-[20rem] vt-justify-between vt-gap-2 vt-bg-white vt-font-normal"
+								>
+									<span className="vt-truncate">
+										{selectedSourceOption?.label || __('Select source...', 'versatile-toolkit')}
+									</span>
+									<ChevronsUpDown className="vt-h-4 vt-w-4 vt-shrink-0 vt-opacity-50" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent className="vt-w-[20rem] vt-p-0" align="start">
+								<Command>
+									<CommandInput placeholder={__('Search source...', 'versatile-toolkit')} />
+									<CommandList>
+										<CommandEmpty>{__('No source found.', 'versatile-toolkit')}</CommandEmpty>
+										<CommandGroup>
+											{generalOptions.map((option) => (
+												<CommandItem
+													key={option.value}
+													value={option.label}
+													onSelect={() => handleSourceFilterChange(option.value)}
+												>
+													<Check
+														className={cn(
+															'vt-mr-2 vt-h-4 vt-w-4',
+															selectedSource === option.value ? 'vt-opacity-100' : 'vt-opacity-0',
+														)}
+													/>
+													{option.label}
+												</CommandItem>
+											))}
+										</CommandGroup>
+										{pluginOptions.length > 0 && (
+											<CommandGroup heading={__('Plugins', 'versatile-toolkit')}>
+												{pluginOptions.map((option) => (
+													<CommandItem
+														key={option.value}
+														value={option.label}
+														onSelect={() => handleSourceFilterChange(option.value)}
+													>
+														<Check
+															className={cn(
+																'vt-mr-2 vt-h-4 vt-w-4',
+																selectedSource === option.value
+																	? 'vt-opacity-100'
+																	: 'vt-opacity-0',
+															)}
+														/>
+														{option.label}
+													</CommandItem>
+												))}
+											</CommandGroup>
+										)}
+										{themeOptions.length > 0 && (
+											<CommandGroup heading={__('Themes', 'versatile-toolkit')}>
+												{themeOptions.map((option) => (
+													<CommandItem
+														key={option.value}
+														value={option.label}
+														onSelect={() => handleSourceFilterChange(option.value)}
+													>
+														<Check
+															className={cn(
+																'vt-mr-2 vt-h-4 vt-w-4',
+																selectedSource === option.value
+																	? 'vt-opacity-100'
+																	: 'vt-opacity-0',
+															)}
+														/>
+														{option.label}
+													</CommandItem>
+												))}
+											</CommandGroup>
+										)}
+									</CommandList>
+								</Command>
+							</PopoverContent>
+						</Popover>
 						<button
 							title={__('Refresh Log', 'versatile-toolkit')}
 							onClick={handleRefreshLog}
@@ -294,9 +491,9 @@ const debugLog = () => {
 					</div>
 				</div>
 				<ServerDataTable<DebugRow, TFetchDataPromise<DebugRow>, typeof searchParams>
-					key={refreshTrigger} // Force re-render when refreshTrigger changes
+					key={`${refreshTrigger}-${selectedSource}`} // Force re-render when refreshTrigger or source filter changes
 					columns={columns}
-					fetchData={debugLogApi.loadLogContent}
+					fetchData={fetchLogContent}
 					searchParams={searchParams}
 				/>
 			</div>

--- a/src/services/debug-log-services.ts
+++ b/src/services/debug-log-services.ts
@@ -1,7 +1,6 @@
 import config from '@/config';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { VersatileResponseType } from '@/utils/versatile-declaration';
-import { fetchUtil } from '@/utils/request-utils';
 import toast from 'react-hot-toast';
 import { __ } from '@wordpress/i18n';
 
@@ -27,6 +26,13 @@ export interface DebugRow {
     raw_line: string;
     severity: string;
     timestamp: string;
+    file?: string;
+    line?: string;
+    stack_trace?: string;
+    log_from: string;
+    source_type: string;
+    source_slug: string;
+    source_value: string;
 }
 
 export interface DebugLogSearchParams {
@@ -35,6 +41,7 @@ export interface DebugLogSearchParams {
     search?: string;
     sortKey?: string;
     order?: string;
+    source?: string;
 }
 
 export interface DebugLogData {
@@ -157,7 +164,7 @@ export const debugLogApi = {
     },
 
     // Load debug log content with pagination
-    loadLogContent: async ({ page, perPage, search, sortKey, order }: DebugLogSearchParams): Promise<{ data: DebugRow[], total: number, totalPages: number }> => {
+    loadLogContent: async ({ page, perPage, search, sortKey, order, source }: DebugLogSearchParams): Promise<{ data: DebugRow[], total: number, totalPages: number }> => {
         try {
             const params = new URLSearchParams({
                 action: 'versatile_get_debug_log_content',
@@ -167,6 +174,7 @@ export const debugLogApi = {
                 search: String(search || '').trim(),
                 sortKey: String(sortKey || '').trim(),
                 order: String(order?.trim()?.toLowerCase() || ''),
+                source: String(source || 'all').trim(),
             });
 
             const response = await fetch(`${config.ajax_url}?${params}`);
@@ -203,7 +211,7 @@ export const useToggleDebugLog = () => {
 
     return useMutation({
         mutationFn: debugLogApi.toggleDebugLog,
-        onSuccess: (data, variables) => {
+        onSuccess: (_data, variables) => {
             // Invalidate and refetch debug log status
             queryClient.invalidateQueries({ queryKey: ['debugLogStatus'] });
 

--- a/versatile-toolkit.php
+++ b/versatile-toolkit.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Versatile Toolkit
- * Version: 1.0.10
+ * Version: 1.0.11
  * Requires at least: 5.3
  * Requires PHP: 7.4
  * Plugin URI: https://verspark.com/


### PR DESCRIPTION
Add automatic detection of log source (plugins, themes, mu-plugins, WordPress core) for each debug log entry. Add a source filter dropdown to the debug log page UI. Update the backend API to support filtering logs by the source parameter.